### PR TITLE
Add agent operating guide + redesign README (clearer, all 16 domains)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Ronin — operating guide for AI agents
+
+You are an AI agent (Claude Code, Codex, Gemini, or any other) working with Ronin, a library of
+security skills. This file tells you how to use it. Keep it short in your head: **confirm scope →
+pick the skill that matches the task → follow it → prove impact → report.**
+
+## What you have here
+- `skills/<domain>/<slug>/SKILL.md` — 85 trigger-loaded skills across 16 domains (offensive **and**
+  defensive). Each has a `description:` that says *when* to load it, and a body that teaches the mechanism.
+- `CATALOG.md` — the full, browsable index of every skill.
+- `COVERAGE.md` — how skills map to OWASP / MITRE ATT&CK / CWE.
+- `methodology.md` — the full engagement method (this file is the short version).
+
+## Rule zero — scope, always first
+Never scan, request, or exploit anything outside a **confirmed authorization envelope**. Before you
+touch a target, load `skills/tradecraft/tradecraft-scope-roe/SKILL.md` and confirm one of:
+a signed pentest scope, a bug-bounty program the target is in scope for, or systems the user owns.
+**If scope is unclear, STOP and ask the user.** Never touch out-of-scope or third-party systems.
+
+## How to pick a skill
+Match the task in front of you to a skill's `description:` trigger line (skim `CATALOG.md`, or
+grep `skills/`). Load that one `SKILL.md` and work its sections in order:
+**When it applies · Why it works · Method (exact commands) · Gotchas · Verify success.**
+Work one lead at a time; load the next skill as new leads appear.
+
+## The loop (how to work a target)
+1. **Set up** — create the engagement workspace (below); write `scope.txt` (+ `roe.md` for bug bounty).
+2. **Recon** — `recon-*` (subdomains, DNS, content/JS discovery, OSINT, services).
+3. **Attack surface** — route by domain: web → `web-*`, APIs → `api-*`, cloud → `cloud-*`,
+   mobile → `mobile-*`, Active Directory → `ad-*`, LLM/AI targets → `ai-ml/*`, source → `code-review-*`.
+4. **Foothold** — drive a weakness to proven impact; combine small bugs with `exploit-chaining`.
+5. **Escalate & pivot** — `privesc-*`, `ad-*`, `network-pivoting-tunneling`.
+6. **Report** — `reporting-bug-bounty-writeup` or `reporting-pentest-report`.
+7. **Defend** (if asked) — `defense-*` (detection, hardening, DFIR, threat modeling).
+
+## Per-engagement structure (create this, keep it tidy)
+For each target, work inside its own folder so notes and loot never mix or leak:
+
+```
+engagements/<target>/
+  scope.txt      # authorized targets — the hard boundary
+  roe.md         # bug-bounty rules of engagement (rate limits, don'ts, disclosure)
+  notes.md       # timestamped running log — the source of truth for the report
+  findings/      # confirmed findings + evidence, one file per finding
+  loot/          # captured data / artifacts
+```
+
+These paths are git-ignored, so an engagement run inside a clone never pollutes the repo. Keep
+`notes.md` to the teach-the-mechanism standard in `methodology.md` (goal · command · result ·
+why it worked · next lead).
+
+## House rules
+- Teach the mechanism, don't just paste payloads. Prove impact with the least data/action needed.
+- Minimize footprint; clean up test artifacts (accounts, uploads).
+- Authorized use only — this library is for pentest engagements, bug-bounty programs, and defense.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Ronin — for Claude Code
+
+You are in **Ronin**, an open library of security skills. Use it via the operating guide below,
+which applies to every agent:
+
+@AGENTS.md
+
+## Claude Code specifics
+- The files under `skills/` are in the standard **Agent Skills** format. To make them available in
+  every project, symlink them into your user scope once:
+  `ln -s "$PWD/skills" ~/.claude/skills/ronin`
+- When a task matches a skill's trigger, load that `skills/<domain>/<slug>/SKILL.md` and follow it.
+- **Always load `tradecraft-scope-roe` first** and confirm authorization before acting.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **The open library of hacking skills for AI agents.**
 
-Point your agent at Ronin and it works like a seasoned operator — recon to report, offense and defense.
+Point any AI agent at Ronin and it works like a seasoned operator — recon to report, offense and defense.
 
 [![CI](https://github.com/NoorQureshi/ronin/actions/workflows/ci.yml/badge.svg)](https://github.com/NoorQureshi/ronin/actions/workflows/ci.yml)
 ![skills](https://img.shields.io/badge/skills-85-6E56CF)
@@ -13,50 +13,116 @@ Point your agent at Ronin and it works like a seasoned operator — recon to rep
 ![use](https://img.shields.io/badge/use-authorized_only-red)
 ![license](https://img.shields.io/badge/license-MIT-blue)
 
-[Browse the catalog](CATALOG.md) · [Coverage](COVERAGE.md) · [Using Ronin](docs/USING.md) · [Contribute](CONTRIBUTING.md) · [Roadmap](ROADMAP.md)
+[**Use it**](#use-it-with-any-agent) · [Domains](#the-16-domains) · [Catalog](CATALOG.md) · [Coverage](COVERAGE.md) · [Contribute](CONTRIBUTING.md) · [Roadmap](ROADMAP.md)
 
 </div>
 
 ---
 
-Ronin is **not a tool — it's a library.** It's the knowledge of *how the work is actually done* —
-find the bug, prove the impact, escalate, pivot, report, and defend — written as small,
-trigger-tagged **skills**. Drop it in front of any AI agent (Claude Code, Codex, Gemini, a local
-model) and the right skill loads itself for the task in front of it.
+Ronin is **not a tool — it's a library.** It captures *how the work is actually done* — find the
+bug, prove the impact, escalate, pivot, report, and defend — as small, trigger-tagged **skills** in
+the standard Agent-Skills format. Drop it in front of any AI agent and the right skill loads itself
+for the task at hand.
 
 ```text
 you:   "Bug-bounty program acme.com, wildcard in scope. Map it, then hunt the API."
-agent: loads recon-subdomain-enum → recon-content-discovery → api-fuzzing → api-bola …
+agent: loads tradecraft-scope-roe → recon-subdomain-enum → recon-content-discovery → api-fuzzing → api-bola …
 ```
 
-## Why Ronin
+## Use it with any agent
 
-- **Knowledge outlasts tools.** Scanners encode one team's checks at one moment; a library of
-  skills encodes *how to think* — the mechanism, the exact command, the gotcha. Agents change
-  every quarter; the tradecraft doesn't.
-- **Portable, no lock-in.** Plain Markdown in the standard Agent-Skills format. No runtime, no
-  build step, no framework to adopt. Read it, grep it, copy it, improve it.
-- **Offense *and* defense.** Every attack has its counterpart — detection, hardening, DFIR — so
-  the same library serves red and blue.
-- **Built to grow.** A schema keeps every skill consistent; contributions are one Markdown file.
+The skills are plain Markdown, so any agent can use them. Pick your setup:
 
-## What's inside
+<details open>
+<summary><b>Claude Code</b></summary>
 
-**85 skills across 16 domains.** Full, always-current list in **[CATALOG.md](CATALOG.md)**.
+**Option A — open Claude Code inside the repo (zero setup).** It reads `CLAUDE.md`, which teaches it
+how to use the skills and to confirm scope first.
+```bash
+git clone https://github.com/NoorQureshi/ronin && cd ronin
+claude          # then: "Here's my authorized target … start recon"
+```
 
-| Domain | | Domain | | Domain | |
-|---|--:|---|--:|---|--:|
-| `web` | 29 | `cloud` | 6 | `code-review` | 4 |
-| `api` | 8 | `ai-ml` | 6 | `mobile` | 5 |
-| `recon` | 7 | `defense` | 4 | `ad` · `network` · `exploit-dev` · `privesc` · `payloads` · `automation` · `reporting` · `tradecraft` | 2 each |
+**Option B — make the skills available in every project.** Symlink them into your user scope once:
+```bash
+git clone https://github.com/NoorQureshi/ronin
+ln -s "$PWD/ronin/skills" ~/.claude/skills/ronin
+```
+</details>
 
-Every skill carries OWASP / OWASP-LLM / OWASP-API / MITRE ATT&CK / CWE tags, so coverage is
-measurable and gaps are visible — see **[COVERAGE.md](COVERAGE.md)**.
+<details>
+<summary><b>Codex, Gemini & other agents</b></summary>
+
+Clone the repo and open your agent in it — it reads **`AGENTS.md`** (the same operating guide),
+or point the agent at the `skills/` folder. For a one-off, paste a single `SKILL.md` into context.
+```bash
+git clone https://github.com/NoorQureshi/ronin && cd ronin
+```
+</details>
+
+<details>
+<summary><b>Any other / open-source agent</b></summary>
+
+There's no runtime to install. Give the agent read access to `skills/` (and `AGENTS.md` for the
+operating guide), or load the specific `SKILL.md` for the task. That's it.
+</details>
+
+> [!WARNING]
+> **Authorized use only.** The first skill every engagement loads is **`tradecraft-scope-roe`** —
+> Ronin acts only inside a confirmed envelope: a signed pentest scope, a bug-bounty program you're
+> in scope for, or systems you own. Never point it at anything else.
+
+## How an agent works a target
+
+Ronin gives the agent a repeatable loop and a place to keep its work — so runs are consistent
+whether it's Claude Code, Codex, or an open-source agent. (Full method: [`methodology.md`](methodology.md);
+agent guide: [`AGENTS.md`](AGENTS.md).)
+
+```
+1. Scope      confirm authorization, write scope.txt      → tradecraft-scope-roe
+2. Recon      map the surface                             → recon-*
+3. Attack     route by domain (web/api/cloud/mobile/ad…)  → web-*, api-*, cloud-* …
+4. Foothold   prove impact, chain bugs                    → exploit-chaining
+5. Escalate   privesc + lateral movement                  → privesc-*, ad-*, network-*
+6. Report     findings with severity + evidence           → reporting-*
+7. Defend     turn findings into detections               → defense-*
+```
+
+Each engagement gets its own workspace (all git-ignored, so it never pollutes the repo):
+
+```
+engagements/<target>/
+  scope.txt   roe.md   notes.md   findings/   loot/
+```
+
+## The 16 domains
+
+**85 skills.** Every skill is one `SKILL.md`; the full list is in **[CATALOG.md](CATALOG.md)**.
+
+| Domain | Skills | What it covers |
+|---|:--:|---|
+| [`web`](skills/web) | 29 | XSS · SQLi · SSRF · SSTI · IDOR · XXE · CSRF · CORS · LFI · deserialization · OAuth · request smuggling · prototype pollution · cache poisoning · host-header · clickjacking · websocket · race conditions · business logic · upload · JWT · account takeover |
+| [`api`](skills/api) | 8 | BOLA/BFLA · GraphQL · gRPC · mass assignment · auth attacks · fuzzing · versioning · NoSQL injection |
+| [`recon`](skills/recon) | 7 | subdomain enum · DNS analysis · content & JS discovery · OSINT · cloud-asset discovery · service enumeration |
+| [`ai-ml`](skills/ai-ml) | 6 | prompt injection · jailbreaks · RAG poisoning · model extraction · agent/tool abuse · LLM denial-of-wallet |
+| [`cloud`](skills/cloud) | 6 | IMDS→credential theft · S3/bucket exposure · Kubernetes · container escape · IAM privesc · container registries |
+| [`mobile`](skills/mobile) | 5 | Android & iOS assessment · cert-pinning bypass · deep-link abuse · WebView abuse |
+| [`code-review`](skills/code-review) | 4 | review methodology · dangerous-sink catalog · secrets detection · CI/CD pipeline security |
+| [`defense`](skills/defense) | 4 | detection engineering (Sigma/ATT&CK) · hardening baselines · DFIR triage · threat modeling |
+| [`ad`](skills/ad) | 2 | Kerberoasting / AS-REP · Active Directory & pivoting arsenal |
+| [`network`](skills/network) | 2 | non-web service attacks · pivoting & tunneling |
+| [`exploit-dev`](skills/exploit-dev) | 2 | exploit chaining & impact amplification · PoC development |
+| [`privesc`](skills/privesc) | 2 | Linux/Windows arsenal · GTFOBins (sudo/SUID/capabilities) |
+| [`payloads`](skills/payloads) | 2 | WAF/filter bypass · XSS polyglots |
+| [`reporting`](skills/reporting) | 2 | bug-bounty write-up · full pentest report |
+| [`automation`](skills/automation) | 2 | recon pipelines · custom nuclei templates |
+| [`tradecraft`](skills/tradecraft) | 2 | scope & rules-of-engagement · complex multi-stage engagements |
+
+Every skill carries OWASP / OWASP-LLM / OWASP-API / MITRE ATT&CK / CWE tags — see **[COVERAGE.md](COVERAGE.md)**.
 
 ## What a skill looks like
 
-Each `SKILL.md` has a trigger line (so the agent knows *when* to load it) and a body that teaches
-the *mechanism*, not just a payload:
+A trigger line (so the agent knows *when* to load it) and a body that teaches the *mechanism*:
 
 ```markdown
 ---
@@ -72,50 +138,33 @@ cwe: [CWE-918]
 ## When it applies · Why it works · Method (exact commands + flag gloss) · Gotchas · Verify success
 ```
 
-That shape — *when it applies · why it works · method · gotchas · verify* — is the house style,
-and it's what makes the skills useful to a human *and* an agent.
+That shape is the house style — useful to a human *and* an agent.
 
-## Quickstart
+## Why Ronin
 
-```bash
-git clone https://github.com/noorqureshi/ronin
+- **Knowledge outlasts tools.** A library of skills encodes *how to think* — the mechanism, the
+  exact command, the gotcha. Agents change every quarter; the tradecraft doesn't.
+- **Portable, no lock-in.** Plain Markdown, standard Agent-Skills format. No runtime, no build step.
+- **Offense *and* defense.** Every attack has its counterpart — detection, hardening, DFIR.
+- **Built to grow.** A schema keeps every skill consistent; a contribution is one Markdown file.
 
-# Claude Code — expose the skills to your agent:
-ln -s "$PWD/ronin/skills" ~/.claude/skills/ronin      # or: cp -r ronin/skills/* ~/.claude/skills/
-```
+## Contribute
 
-Then describe an **authorized** target and let the agent pick the skills. Codex, Gemini, and local
-models work the same way — point them at `skills/`, or drop a single `SKILL.md` into context.
-Full instructions per agent: **[docs/USING.md](docs/USING.md)**.
-
-> [!WARNING]
-> **Authorized use only.** The first skill every engagement loads is `tradecraft-scope-roe`.
-> Ronin operates only inside a confirmed authorization envelope — a signed pentest scope, a
-> bug-bounty program you're in scope for, or systems you own. Never point it at anything else.
-
-## Contribute — this is the point
-
-Ronin gets sharper with every skill added, and adding one is deliberately easy: **it's a single
-Markdown file, no code.**
+Ronin gets sharper with every skill added — and adding one is a single Markdown file, no code:
 
 ```bash
 cp skills/_templates/technique.md skills/<domain>/<slug>/SKILL.md
-# write it, then:
-python3 tools/catalog.py            # validate + regenerate the catalog
+python3 tools/catalog.py            # validate + regenerate the indexes
 ```
 
-- **Not sure what to write?** The **[Roadmap](ROADMAP.md)** lists wanted skills — the 🟢 ones are
-  great first contributions.
-- **Have a technique you've used on a real (authorized) target?** That's exactly what belongs here.
-- **Blue team?** Detection, hardening, and DFIR skills are just as welcome as offensive ones.
-
-Full guide, house style, and PR checklist: **[CONTRIBUTING.md](CONTRIBUTING.md)**. Every PR is
-schema-validated by CI, so it's hard to get the format wrong.
+New to it? The **[Roadmap](ROADMAP.md)** lists wanted skills (🟢 = good first one). Full guide and
+PR checklist in **[CONTRIBUTING.md](CONTRIBUTING.md)**; CI schema-validates every PR.
 
 ## Layout
 
 ```text
 skills/<domain>/<slug>/SKILL.md   the library (the point of the repo)
+AGENTS.md · CLAUDE.md             operating guide any agent reads in-repo
 methodology.md                    the engagement loop · scope rule · note standard
 schemas/skill.schema.json         the skill contract (validated in CI)
 tools/catalog.py                  validate skills + regenerate CATALOG.md / COVERAGE.md


### PR DESCRIPTION
Makes Ronin usable the instant an agent opens the repo, and much clearer to follow.

- **`AGENTS.md`** — operating guide any agent reads (Claude Code, Codex, Gemini, open-source): scope-first rule, how to pick a skill, the 7-step loop, and a **per-engagement workspace structure** (`engagements/<target>/` with `scope.txt·roe.md·notes.md·findings/·loot/`, all git-ignored).
- **`CLAUDE.md`** — imports `AGENTS.md` (`@AGENTS.md`) + Claude Code specifics (symlink skills).
- **README redesign** — a clear "Use it with any agent" section (Claude Code / Codex / others), the operating loop + engagement structure, and **all 16 domains** in one readable table showing what each covers.

No skill/content changes; all 85 still validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCLFGvZyJLY5oa5EpqVv4N

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCLFGvZyJLY5oa5EpqVv4N)_